### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ git clone git@github.com:interchainberlin/pooltoy.git
 
 cd pooltoy
 
-./scripts/init.sh
-
 make install
+
+./scripts/init.sh
 ```
 ## Start pooltoy
 ```shell


### PR DESCRIPTION
Shouldn't `./scripts/init.sh` be run after `make install`? Seeing as pooltoy is a command not available until after `make install`.