### PR TITLE
Update ratelimit to expire after single 24 hour period

### DIFF
--- a/x/faucet/keeper/keeper.go
+++ b/x/faucet/keeper/keeper.go
@@ -68,7 +68,7 @@ func (k Keeper) MintAndSend(ctx sdk.Context, msg *types.MsgMint) error {
 	}
 	m := k.getMintHistory(ctx, a)
 	currentTime := time.Unix(mintTime, 0)
-	midnight := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, time.Local)
+	midnight := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, time.UTC)
 
 	if k.isPresent(ctx, a) &&
 		time.Unix(int64(m.Lasttime), 0).After(midnight) {

--- a/x/faucet/keeper/keeper.go
+++ b/x/faucet/keeper/keeper.go
@@ -61,14 +61,17 @@ func (k Keeper) MintAndSend(ctx sdk.Context, msg *types.MsgMint) error {
 		return types.ErrCantWithdrawStake
 	}
 
-	// refuse mint in 24 hours
+	// Refuse mint within same 24 hour period from midnight on one day to the following day
 	a, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {
 		return err
 	}
 	m := k.getMintHistory(ctx, a)
+	currentTime := time.Unix(mintTime, 0)
+	midnight := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, time.Local)
+
 	if k.isPresent(ctx, a) &&
-		time.Unix(int64(m.Lasttime), 0).Add(k.Limit).UTC().After(time.Unix(mintTime, 0)) {
+		time.Unix(int64(m.Lasttime), 0).After(midnight) {
 		return types.ErrWithdrawTooOften
 	}
 

--- a/x/faucet/keeper/query_server.go
+++ b/x/faucet/keeper/query_server.go
@@ -48,7 +48,7 @@ func (k Keeper) QueryWhenBrr(c context.Context, req *types.QueryWhenBrrRequest) 
 	isAfterMidnight := lastTime.After(midnight)
 
 	if isAfterMidnight {
-		timeLeft = int64(midnight.Add(24 * time.Hour).UTC().Sub(currentTime).Seconds())
+		timeLeft = int64(midnight.AddDate(0, 0, 1).Sub(currentTime).Seconds())
 	} else {
 		timeLeft = 0
 	}

--- a/x/faucet/keeper/query_server.go
+++ b/x/faucet/keeper/query_server.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"time"
 
@@ -45,10 +46,19 @@ func (k Keeper) QueryWhenBrr(c context.Context, req *types.QueryWhenBrrRequest) 
 	lastTime := time.Unix(m.Lasttime, 0)
 	currentTime := time.Unix(mintTime, 0)
 
-	lastTimePlusLimit := lastTime.Add(k.Limit).UTC()
-	isAfter := lastTimePlusLimit.After(currentTime)
-	if isAfter {
-		timeLeft = int64(lastTime.Add(k.Limit).UTC().Sub(currentTime).Seconds())
+	hr, min, sec := currentTime.Clock()
+	backHours := currentTime.Add(-time.Duration(hr) * time.Hour)
+	backMin := backHours.Add(-time.Duration(min) * time.Minute)
+	midnight := backMin.Add(-time.Duration(sec) * time.Second)
+
+	fmt.Println("lastTime: ", lastTime)
+	fmt.Println("currentTime: ", currentTime)
+	fmt.Println("Back in time: ", midnight)
+
+	isAfterMidnight := lastTime.After(midnight)
+
+	if isAfterMidnight {
+		timeLeft = int64(midnight.Add(24 * time.Hour).UTC().Sub(lastTime).Seconds())
 	} else {
 		timeLeft = 0
 	}

--- a/x/faucet/keeper/query_server.go
+++ b/x/faucet/keeper/query_server.go
@@ -2,7 +2,6 @@ package keeper
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"time"
 
@@ -45,20 +44,11 @@ func (k Keeper) QueryWhenBrr(c context.Context, req *types.QueryWhenBrrRequest) 
 
 	lastTime := time.Unix(m.Lasttime, 0)
 	currentTime := time.Unix(mintTime, 0)
-
-	hr, min, sec := currentTime.Clock()
-	backHours := currentTime.Add(-time.Duration(hr) * time.Hour)
-	backMin := backHours.Add(-time.Duration(min) * time.Minute)
-	midnight := backMin.Add(-time.Duration(sec) * time.Second)
-
-	fmt.Println("lastTime: ", lastTime)
-	fmt.Println("currentTime: ", currentTime)
-	fmt.Println("Back in time: ", midnight)
-
+	midnight := time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), 0, 0, 0, 0, time.Local)
 	isAfterMidnight := lastTime.After(midnight)
 
 	if isAfterMidnight {
-		timeLeft = int64(midnight.Add(24 * time.Hour).UTC().Sub(lastTime).Seconds())
+		timeLeft = int64(midnight.Add(24 * time.Hour).UTC().Sub(currentTime).Seconds())
 	} else {
 		timeLeft = 0
 	}


### PR DESCRIPTION
This PR changes the rate limit for minting a token for another user. Previously a user could only mint a new token every 24 hours from the time they last minted. This proposed change restricts the limit to a single 24 hour period from midnight on the previous day to midnight of the current day, effectively resetting the rate limit for all users daily at `00:00:00 +0100 CET`. 

**Testing**
1. Initialize pooltoy by running `init.sh` and `pooltoy start`
2. Mint a 🚀 for user `U01JT5U5WK0` from `alice` 
```
pooltoy tx faucet mintfor $(pooltoy keys show U01JT5U5WK0 -a) 🚀 --from alice -y
```
3. Check the balance for user `U01JT5U5WK0`. This should reflect an additional 🚀 to their balance.
```
pooltoy query bank balances $(pooltoy keys show U01JT5U5WK0 -a) -o json
```
4. Check when `alice` is allowed to mint again. This should reflect the delta of the number of seconds between the call and upcoming midnight of the current day. Previously running this immediatly after minting would have returned a number around `84,400` seconds.
```
pooltoy q faucet when-brrr $(pooltoy keys show alice -a)
```
5. Try minting another 🚀 for user `U01JT5U5WK0` from `alice`. There should be no change to the user's balance.
6. For those with tremendous patience, try again just after midnight to see the rate limit expire for `alice`.